### PR TITLE
Take into account the idColumn for objection models when creating the adapter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ class Service extends AdapterService {
     const whitelist = Object.values(OPERATORS).concat(options.whitelist || [])
 
     super(Object.assign({
-      id: 'id',
+      id: options.model.idColumn || 'id',
       whitelist
     }, options))
 


### PR DESCRIPTION
This small patch takes into account the 'idColumn' of an objection model.

This allows making updates and .get() requests in the service while having a key other than the default one, or a composite key.

Objection documentation for idColumn: http://vincit.github.io/objection.js/#idcolumn
