### PR TITLE
Do not ignore types folder when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "main": "lib/",
   "types": "types",
   "files": [
-    "lib"
+    "lib",
+    "types"
   ],
   "scripts": {
     "prepare": "npm run compile",


### PR DESCRIPTION
Unlike [`feathers-mongoose`](https://github.com/feathersjs-ecosystem/feathers-mongoose/blob/master/package.json) and [`feathers-knex`](https://github.com/feathersjs-ecosystem/feathers-knex/blob/master/package.json) (just examples) `feathers-objection` [has a `files` field](https://github.com/feathersjs-ecosystem/feathers-objection/blob/27b9f691ec94b2006e7c6d517ead6dacfb699c0d/package.json#L38) in its package.json. Which currently does not include `types` folder, so it is not included in published package.

But actually i think it is better to remove `files` field and depend on `.npmignore` (which already exist) to filter stuff out to be consistent with other feathers adapters.