### PR TITLE
Fix types typos

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,7 @@ import { AdapterService, ServiceOptions, InternalServiceMethods } from '@feather
 import { Model } from 'objection';
 
 export interface ObjectionServiceOptions extends ServiceOptions {
-  Model: any;
+  model: typeof Model;
   idSeparator: string;
   jsonSchema: any;
   allowedEager: string;
@@ -18,7 +18,7 @@ export interface ObjectionServiceOptions extends ServiceOptions {
 }
 
 export class Service<T = any> extends AdapterService implements InternalServiceMethods<T> {
-  Model: Model;
+  Model: typeof Model;
   options: ObjectionServiceOptions;
 
   constructor(config?: Partial<ObjectionServiceOptions>);

--- a/types/index.test.ts
+++ b/types/index.test.ts
@@ -8,5 +8,7 @@ class Todo extends Model {
 }
 
 const myService = service({
-  Model: Todo
+  model: Todo
 });
+
+myService.Model.tableName;


### PR DESCRIPTION
1) `ObjectionServiceOptions` has [`model`](https://github.com/feathersjs-ecosystem/feathers-objection/blob/57649fe828c2bdfdeb99517b06e7db5debdb74f0/src/index.js#L73) key, not `Model`. (Last comment in #56 is about this.)

2) `ObjectionServiceOptions.model` and `Service.Model` are of type `typeof Model` instead of just `Model` because it is not an instance, but a model class itself.