### PR TITLE
Parse relation expressions at service creation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,10 @@ with adding a new client which is a relationship for companies. The client
 without the ID would be inserted and related. The client with the ID will just
 be updated (if there are any changes at all).
 
+#### Params Operators
+
+- **`mergeAllowUpsert`** - Merges give expression into `allowedUpsert`.
+
 ### Graph insert
 
 Arbitrary relation graphs can be inserted using the insertGraph method. Provides
@@ -354,6 +358,10 @@ included in `$eager` query._
 - **`insertGraphOptions`** - See
   [`insertGraphOptions`](https://vincit.github.io/objection.js/api/types/#type-insertgraphoptions)
   documentation.
+
+#### Params Operators
+
+- **`mergeAllowInsert`** - Merges give expression into `allowedInsert`.
 
 ### Service
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { AdapterService } from '@feathersjs/adapter-commons';
 import errors from '@feathersjs/errors';
-import { ref } from 'objection';
+import { ref, RelationExpression } from 'objection';
 import utils from './utils';
 import errorHandler from './error-handler';
 
@@ -91,13 +91,13 @@ class Service extends AdapterService {
 
     this.idSeparator = options.idSeparator || ',';
     this.jsonSchema = options.model.jsonSchema;
-    this.allowedEager = options.allowedEager || '[]';
+    this.allowedEager = RelationExpression.create(options.allowedEager || '[]');
     this.namedEagerFilters = options.namedEagerFilters;
     this.eagerFilters = options.eagerFilters;
-    this.allowedInsert = options.allowedInsert;
+    this.allowedInsert = options.allowedInsert && RelationExpression.create(options.allowedInsert);
     this.insertGraphOptions = options.insertGraphOptions;
     this.createUseUpsertGraph = options.createUseUpsertGraph;
-    this.allowedUpsert = options.allowedUpsert;
+    this.allowedUpsert = options.allowedUpsert && RelationExpression.create(options.allowedUpsert);
     this.upsertGraphOptions = options.upsertGraphOptions;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,8 @@ const NON_COMPARISON_OPERATORS = [
   '?&'
 ];
 
+const NO_RELATIONS = RelationExpression.create('[]');
+
 /**
  * Class representing an feathers adapter for Objection.js ORM.
  * @param {object} options
@@ -91,7 +93,7 @@ class Service extends AdapterService {
 
     this.idSeparator = options.idSeparator || ',';
     this.jsonSchema = options.model.jsonSchema;
-    this.allowedEager = RelationExpression.create(options.allowedEager || '[]');
+    this.allowedEager = options.allowedEager && RelationExpression.create(options.allowedEager);
     this.namedEagerFilters = options.namedEagerFilters;
     this.eagerFilters = options.eagerFilters;
     this.allowedInsert = options.allowedInsert && RelationExpression.create(options.allowedInsert);
@@ -235,6 +237,18 @@ class Service extends AdapterService {
     });
   }
 
+  mergeRelations (optionRelations, paramRelations) {
+    if (!paramRelations) {
+      return optionRelations;
+    }
+
+    if (!optionRelations) {
+      return RelationExpression.create(paramRelations);
+    }
+
+    return optionRelations.merge(paramRelations);
+  }
+
   _createQuery (params = {}) {
     const trx = params.transaction ? params.transaction.trx : null;
     return this.Model.query(trx);
@@ -242,17 +256,14 @@ class Service extends AdapterService {
 
   createQuery (params = {}) {
     const { filters, query } = this.filterQuery(params);
-    let q = this._createQuery(params)
-      .skipUndefined()
-      .allowEager(this.allowedEager);
+    const q = this._createQuery(params).skipUndefined();
 
-    if (params.mergeAllowEager) {
-      q.mergeAllowEager(params.mergeAllowEager);
-    }
+    const allowEager = this.mergeRelations(this.allowedEager, params.mergeAllowEager);
+    q.allowEager(allowEager || NO_RELATIONS);
 
     // $select uses a specific find syntax, so it has to come first.
     if (filters.$select) {
-      q = q.select(...filters.$select.concat(`${this.Model.tableName}.${this.id}`));
+      q.select(...filters.$select.concat(`${this.Model.tableName}.${this.id}`));
     }
 
     // $eager for Objection eager queries
@@ -290,7 +301,7 @@ class Service extends AdapterService {
     }
 
     if (query && query.$pick) {
-      q = q.pick(query.$pick);
+      q.pick(query.$pick);
       delete query.$pick;
     }
 
@@ -299,7 +310,7 @@ class Service extends AdapterService {
 
     if (filters.$sort) {
       Object.keys(filters.$sort).forEach(key => {
-        q = q.orderBy(key, filters.$sort[key] === 1 ? 'asc' : 'desc');
+        q.orderBy(key, filters.$sort[key] === 1 ? 'asc' : 'desc');
       });
     }
 
@@ -403,14 +414,16 @@ class Service extends AdapterService {
   _create (data, params) {
     const create = (data, params) => {
       const q = this._createQuery(params);
+      const allowedUpsert = this.mergeRelations(this.allowedUpsert, params.mergeAllowUpsert);
+      const allowedInsert = this.mergeRelations(this.allowedInsert, params.mergeAllowInsert);
 
       if (this.createUseUpsertGraph) {
-        if (this.allowedUpsert) {
-          q.allowUpsert(this.allowedUpsert);
+        if (allowedUpsert) {
+          q.allowUpsert(allowedUpsert);
         }
         q.upsertGraphAndFetch(data, this.upsertGraphOptions);
-      } else if (this.allowedInsert) {
-        q.allowInsert(this.allowedInsert);
+      } else if (allowedInsert) {
+        q.allowInsert(allowedInsert);
         q.insertGraph(data, this.insertGraphOptions);
       } else {
         q.insert(data, this.id);
@@ -465,9 +478,10 @@ class Service extends AdapterService {
           }
         }
 
-        if (this.allowedUpsert) {
+        const allowedUpsert = this.mergeRelations(this.allowedUpsert, params.mergeAllowUpsert);
+        if (allowedUpsert) {
           return this._createQuery(params)
-            .allowUpsert(this.allowedUpsert)
+            .allowUpsert(allowedUpsert)
             .upsertGraphAndFetch(newObject, this.upsertGraphOptions);
         }
 
@@ -505,11 +519,12 @@ class Service extends AdapterService {
   _patch (id, data, params) {
     let { filters, query } = this.filterQuery(params);
 
-    if (this.allowedUpsert && id !== null) {
+    const allowedUpsert = this.mergeRelations(this.allowedUpsert, params.mergeAllowUpsert);
+    if (allowedUpsert && id !== null) {
       const dataCopy = Object.assign({}, data, this.getIdsQuery(id, null, false));
 
       return this._createQuery(params)
-        .allowUpsert(this.allowedUpsert)
+        .allowUpsert(allowedUpsert)
         .upsertGraphAndFetch(dataCopy, this.upsertGraphOptions);
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,7 +15,7 @@ import PeopleRoomsCustomIdSeparator from './people-rooms-custom-id-separator';
 import Company from './company';
 import Employee from './employee';
 import Client from './client';
-import { Model } from 'objection';
+import { Model, RelationExpression } from 'objection';
 
 const testSuite = adapterTests([
   '.options',
@@ -295,7 +295,7 @@ describe('Feathers Objection Service', () => {
 
     describe('when missing allowedEager', () => {
       it('sets the default to be empty string', () => {
-        expect(people.allowedEager).to.equal('[]');
+        expect(people.allowedEager).to.deep.equal(RelationExpression.create('[]'));
       });
     });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,13 +7,13 @@ export interface ObjectionServiceOptions extends ServiceOptions {
   model: typeof Model;
   idSeparator: string;
   jsonSchema: any;
-  allowedEager: string;
+  allowedEager: string | object;
   namedEagerFilters: any;
   eagerFilters: any;
-  allowedInsert: any;
+  allowedInsert: string | object;
   insertGraphOptions: any;
   createUseUpsertGraph: any;
-  allowedUpsert: any;
+  allowedUpsert: string | object;
   upsertGraphOptions: any;
 }
 


### PR DESCRIPTION
Parse relation expressions options (`allowedEager`, `allowedInsert` and `allowedUpsert`) in constructor instead of passing strings for parsing every service call.

Also in types indicate that those options can be not only strings but objects too (an objection notation of a relation or a result of `RelationExpression.create`).