### PR TITLE
$null feature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ const METHODS = {
   $and: 'andWhere',
   $ne: 'whereNot',
   $in: 'whereIn',
-  $nin: 'whereNotIn'
+  $nin: 'whereNotIn',
+  $null: 'whereNull'
 };
 
 const OPERATORS = {
@@ -199,6 +200,15 @@ class Service extends AdapterService {
               });
             });
           });
+        }
+
+        if (key === '$null') {
+          if (value === 'true') {
+            return query.whereNull(column);
+          }
+          if (value === 'false') {
+            return query.whereNotNull(column);
+          }
         }
 
         return query[method].call(query, column, value); // eslint-disable-line no-useless-call


### PR DESCRIPTION
Added a $null key to return query.whereNull or query.whereNotNull based on $null value of 'true' / 'false'.

Now in client REST application can have query like so:

```
$and: [
  {
    $or: [
      { 'beginAvailability': { $null: true }},
      { 'beginAvailability': { $lte: now.toISOString() }}
    ]
  },
  {
    $or: [
      { 'endAvailability': { $null: true }},
      { 'endAvailability': { $gt: now.toISOString() }}
    ]
  }
]
```