### PR TITLE
Set schema option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ class Service extends AdapterService {
     this.createUseUpsertGraph = options.createUseUpsertGraph;
     this.allowedUpsert = options.allowedUpsert && RelationExpression.create(options.allowedUpsert);
     this.upsertGraphOptions = options.upsertGraphOptions;
+    this.schema = options.schema;
   }
 
   get Model () {
@@ -276,7 +277,7 @@ class Service extends AdapterService {
 
   _createQuery (params = {}) {
     const trx = params.transaction ? params.transaction.trx : null;
-    const schema = params.schema || this.options.schema;
+    const schema = params.schema || this.schema;
     let query = this.Model.query(trx);
 
     return schema ? query.withSchema(schema) : query;

--- a/src/index.js
+++ b/src/index.js
@@ -278,6 +278,7 @@ class Service extends AdapterService {
     const trx = params.transaction ? params.transaction.trx : null;
     const schema = params.schema || this.options.schema;
     let query = this.Model.query(trx);
+
     return schema ? query.withSchema(schema) : query;
   }
 


### PR DESCRIPTION
feathers-knex allows the setting of the database schema in the service options.
feathers-objection does not, it always uses the "public" schema (in Postgres).

This change allows that by executing withScema() on the query builder.
Can either set the schema through the service options or in `params` if done dynamically through a hook.