### PR TITLE
Fix for default operators getting overwritten by options.whitelist instead of concat

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ class Service extends AdapterService {
     }
 
     const whitelist = Object.values(OPERATORS).concat(options.whitelist || []);
-
+    delete options.whitelist;
     super(Object.assign({
       id: options.model.idColumn || 'id',
       whitelist

--- a/src/index.js
+++ b/src/index.js
@@ -84,11 +84,9 @@ class Service extends AdapterService {
     }
 
     const whitelist = Object.values(OPERATORS).concat(options.whitelist || []);
-    delete options.whitelist;
-    super(Object.assign({
-      id: options.model.idColumn || 'id',
-      whitelist
-    }, options));
+    const id = options.model.idColumn || 'id';
+
+    super(Object.assign({ id }, options, { whitelist }));
 
     this.idSeparator = options.idSeparator || ',';
     this.jsonSchema = options.model.jsonSchema;


### PR DESCRIPTION
According to documentation, `whitelist` is meant for operators in addition to the default operators. 
> whitelist (optional) - List of additional query operators to allow (e.g. [ '$eager', '$joinRelation' ]).

But, currently providing `options.whitelist` is overriding the default operators instead of extending them. 

The code in Line 86 for concatenating options.whitelist to the default OPERATORS effectively became a no-op, because of the `Object.assign` in the next line.

I have fixed it by deleting `options.whitelist` before merging
