### PR TITLE
joinEager Fixes + $not Operator all with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ Note that all this eager related options are optional.
 
 - **`$noSelect`** - skips SELECT queries in create, patch & remove requests. response data will be based on the input data.
 
-- **`$null`** - filter based on if a column is NULL with REST support, e.g. `companies.find({ query: { ceo: { $null: false } } })`, `companies.find({ query: { ceo: { $null: 'false' } } })` 
+- **`$null`** - filter based on if a column is NULL with REST support, e.g. `companies.find({ query: { ceo: { $null: false } } })`, `companies.find({ query: { ceo: { $null: 'false' } } })`
+
+- **`$not`** - filter based on if a query is NOT true. It can be used with an object `$not: { name: { $in: ['craig', 'tim'] } }` or array `$not: [ { $id: 1 }, { $id: 2 } ]`
 
 - **`$between`** - filter based on if a column value is between range of values
 
@@ -336,10 +338,9 @@ app.service('companies').find({
 
 Arbitrary relation graphs can be upserted (insert + update + delete) using the
 upsertGraph method. See
-[`examples`](https://vincit.github.io/objection.js/guide/query-examples.html#graph-upserts) for a better
-explanation.  
-Runs on `update` and `patch` service methods when `id` is set.
-When the data object also contains `id` then both must be the same or an error is thrown.
+[`examples`](https://vincit.github.io/objection.js/guide/query-examples.html#graph-upserts) for a better explanation.  
+
+Runs on `update` and `patch` service methods when `id` is set. When the `data` object also contains `id`, then both must be the same or an error is thrown.
 
 #### Service Options
 
@@ -384,8 +385,9 @@ be updated (if there are any changes at all).
 ### Graph insert
 
 Arbitrary relation graphs can be inserted using the insertGraph method. Provides
-the ability to relate the inserted object with its associations. Runs on the
-`.create(data, params)` service method.
+the ability to relate the inserted object with its associations.  
+
+Runs on the `.create(data, params)` service method.
 
 #### Service Options
 
@@ -866,16 +868,16 @@ The following breaking changes have been introduced:
 
 `feathers-objection` 6.0.0 comes with usability and security updates
 
-- `$not` operator is now available. It can be used with object `$not: { name: { $in: ["craig", "tim"] } }` or arrays `$not: [ { $id: 1 }, { $id: 2 } ]`
+- `$not` operator is now available. It can be used with an object `$not: { name: { $in: ["craig", "tim"] } }` or array `$not: [ { $id: 1 }, { $id: 2 } ]`
 - `$eager` is no longer needed with upsert operations
 
 The following breaking changes have been introduced:
 
-- graph upsert require `data.id` and `context.id` to match if both are given. Thus removing a security weekness. 
-- `$noSelect` always return the input data (this was not always the case)
+- Graph upsert now requires that `id` fields in the `data` object will match the `id` argument
+- `$noSelect` now always return the input data
 - `$select` is now honored with upsert methods
 - `patch` method now enforce `params.query` with upsert
-- `get` and `update` methods use `id` __and__ all `params.query` including another `id` if there is one. So ids must match or query will return a NotFound error
+- NotFound error will be thrown when `get` & `update` methods are called with different values in `id` & `params.query.id`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ operators are:
 '$notILike',
 '$or',
 '$and',
-'$sort'
+'$sort',
+'$not'
 ```
 
 ### Eager Queries
@@ -338,9 +339,7 @@ upsertGraph method. See
 [`examples`](https://vincit.github.io/objection.js/guide/query-examples.html#graph-upserts) for a better
 explanation.  
 Runs on `update` and `patch` service methods when `id` is set.
-
-_The relation being upserted must also be present in `allowedEager` option and
-included in `$eager` query when using the `update` service method._
+When the data object also contains `id` then both must be the same or an error is thrown.
 
 #### Service Options
 
@@ -387,9 +386,6 @@ be updated (if there are any changes at all).
 Arbitrary relation graphs can be inserted using the insertGraph method. Provides
 the ability to relate the inserted object with its associations. Runs on the
 `.create(data, params)` service method.
-
-_The relation being created must also be present in `allowedEager` option and
-included in `$eager` query._
 
 #### Service Options
 
@@ -866,8 +862,23 @@ The following breaking changes have been introduced:
 - `namedEagerFilters` service option was removed. use Model's [`modifiers`](https://vincit.github.io/objection.js/recipes/modifiers.html#modifiers) instead
 - Model's `namedFilters` property was renamed to `modifiers`
 
+## Migrating to `feathers-objection` v6
+
+`feathers-objection` 6.0.0 comes with usability and security updates
+
+- `$not` operator is now available. It can be used with object `$not: { name: { $in: ["craig", "tim"] } }` or arrays `$not: [ { $id: 1 }, { $id: 2 } ]`
+- `$eager` is no longer needed with upsert operations
+
+The following breaking changes have been introduced:
+
+- graph upsert require `data.id` and `context.id` to match if both are given. Thus removing a security weekness. 
+- `$noSelect` always return the input data (this was not always the case)
+- `$select` is now honored with upsert methods
+- `patch` method now enforce `params.query` with upsert
+- `get` and `update` methods use `id` __and__ all `params.query` including another `id` if there is one. So ids must match or query will return a NotFound error
+
 ## License
 
-Copyright © 2019
+Copyright © 2020
 
 Licensed under the [MIT license](LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2955,9 +2955,9 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "dev": true,
       "requires": {
         "readable-stream": "^2.3.5",

--- a/src/index.js
+++ b/src/index.js
@@ -679,11 +679,13 @@ class Service extends AdapterService {
     const allowedUpsert = this.mergeRelations(this.allowedUpsert, params.mergeAllowUpsert);
     if (allowedUpsert && id !== null) {
       const dataCopy = Object.assign({}, data, this.getIdsQuery(id, null, false));
-
-      return this._createQuery(params)
-        .allowGraph(allowedUpsert)
-        .upsertGraphAndFetch(dataCopy, this.upsertGraphOptions)
-        .then(this._selectFields(params, data));
+      // Get object first to ensure it satisfy user query
+      return this._get(id, params).then(() => {
+        return this._createQuery(params)
+          .allowGraph(allowedUpsert)
+          .upsertGraphAndFetch(dataCopy, this.upsertGraphOptions)
+          .then(this._selectFields(params, data));
+      });
     }
 
     const dataCopy = Object.assign({}, data);

--- a/src/index.js
+++ b/src/index.js
@@ -168,13 +168,12 @@ class Service extends AdapterService {
     if (params.$allowRefs) { delete params.$allowRefs; }
 
     Object.keys(params || {}).forEach(key => {
-
       let value = params[key];
 
-      if (key === '$not'){
+      if (key === '$not') {
         const self = this;
-        if (Array.isArray(value)){ // Array = $and operator
-          value = { $and : value }
+        if (Array.isArray(value)) { // Array = $and operator
+          value = { $and: value };
         }
         return query.whereNot(function () {
           // continue with all queries inverted

--- a/src/index.js
+++ b/src/index.js
@@ -323,7 +323,9 @@ class Service extends AdapterService {
       delete query.$eager;
     }
 
-    if (query && query.$joinEager) {
+    const joinEager = query && query.$joinEager;
+
+    if (joinEager) {
       q.withGraphJoined(query.$joinEager, eagerOptions);
 
       delete query.$joinEager;
@@ -338,7 +340,7 @@ class Service extends AdapterService {
     }
 
     if (query && query.$mergeEager) {
-      q[query.$joinEager ? 'withGraphJoined' : 'withGraphFetched'](query.$mergeEager, eagerOptions);
+      q[joinEager ? 'withGraphJoined' : 'withGraphFetched'](query.$mergeEager, eagerOptions);
 
       delete query.$mergeEager;
     }
@@ -439,6 +441,10 @@ class Service extends AdapterService {
         if (query.$joinRelation) {
           countQuery
             .joinRelated(query.$joinRelation)
+            .countDistinct({ total: countColumns });
+        } else if (query.$joinEager) {
+          countQuery
+            .joinRelated(query.$joinEager)
             .countDistinct({ total: countColumns });
         } else if (countColumns.length > 1) {
           countQuery.countDistinct({ total: countColumns });

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ const METHODS = {
   $ne: 'whereNot',
   $in: 'whereIn',
   $nin: 'whereNotIn',
-  $null: 'whereNull'
+  $null: 'whereNull',
+  $not: 'whereNot'
 };
 
 const OPERATORS = {
@@ -27,7 +28,8 @@ const OPERATORS = {
   ilike: '$ilike',
   notILike: '$notILike',
   or: '$or',
-  and: '$and'
+  and: '$and',
+  whereNot: '$not'
 };
 
 const OPERATORS_MAP = {
@@ -166,7 +168,19 @@ class Service extends AdapterService {
     if (params.$allowRefs) { delete params.$allowRefs; }
 
     Object.keys(params || {}).forEach(key => {
+
       let value = params[key];
+
+      if (key === '$not'){
+        const self = this;
+        if (Array.isArray(value)){ // Array = $and operator
+          value = { $and : value }
+        }
+        return query.whereNot(function () {
+          // continue with all queries inverted
+          self.objectify(this, value, parentKey, methodKey, allowRefs);
+        });
+      }
 
       if (utils.isPlainObject(value)) {
         return this.objectify(query, value, key, parentKey, allowRefs);

--- a/src/index.js
+++ b/src/index.js
@@ -332,8 +332,9 @@ class Service extends AdapterService {
       const matches = item.match(/^(?:ref\((\S+)\)|(\S+))(?: as (.+))?$/);
       if (matches) {
         const tableField = matches[1] || matches[2];
-        const alias = matches[3] || tableField;
-        result[tableField] = alias;
+        const field = tableField.startsWith(`${this.Model.tableName}.`) ? tableField.substr(this.Model.tableName.length + 1) : tableField;
+        const alias = matches[3] || field;
+        result[field] = alias;
       } else {
         // Can't parse $select !
         throw new errors.BadRequest(`${item} is not a valid select statement`);
@@ -348,7 +349,7 @@ class Service extends AdapterService {
         return originalData;
       }
       // Remove not selected fields
-      if (params.query && params.query.$select) {
+      if (params.query && params.query.$select && !params.query.$select.find(field => field === '*' || field === `${this.Model.tableName}.*`)) {
         const $fieldsOrAliases = this._selectAliases(params.query.$select);
         for (const key of Object.keys(newObject)) {
           if (!$fieldsOrAliases[key]) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -791,7 +791,7 @@ describe('Feathers Objection Service', () => {
     });
 
     it('allows mergeEager queries with joinEager', () => {
-      return companies.find({ query: { $joinEager: 'employees', $mergeEager: 'ceos', 'employees.name': { '$like': '%'} }, mergeAllowEager: '[employees, ceos]' }).then(data => {
+      return companies.find({ query: { $joinEager: 'employees', $mergeEager: 'ceos', 'employees.name': { $like: '%' } }, mergeAllowEager: '[employees, ceos]' }).then(data => {
         expect(data[0].employees).to.be.ok;
         expect(data[0].ceos).to.be.ok;
       });
@@ -1246,7 +1246,7 @@ describe('Feathers Objection Service', () => {
   describe('$not method', () => {
     before(async () => {
       const persons = await people.find();
-  
+
       for (const person of persons) { await people.remove(person.id); }
 
       await people
@@ -1281,25 +1281,24 @@ describe('Feathers Objection Service', () => {
     });
 
     it('$not with $and in query', () => {
-      return people.find({ query: { $not: { $and :[{ name: 'John' }, { name: 'Dave' }]} } }).then(data => {
+      return people.find({ query: { $not: { $and: [{ name: 'John' }, { name: 'Dave' }] } } }).then(data => {
         expect(data.length).to.be.equal(3);
         expect(data[0].name).to.be.equal('John');
       });
     });
 
     it('$not with $or in query', () => {
-      return people.find({ query: { $not: { $or : [ { name: 'John' }, { name: 'Dave' }]}  } } ).then(data => {
+      return people.find({ query: { $not: { $or: [{ name: 'John' }, { name: 'Dave' }] } } }).then(data => {
         expect(data.length).to.be.equal(1);
         expect(data[0].name).to.be.equal('Dada');
       });
     });
 
     it('$not with $null in query', () => {
-      return people.find({ query: { $not: { name: { $null: true } }  } } ).then(data => {
+      return people.find({ query: { $not: { name: { $null: true } } } }).then(data => {
         expect(data.length).to.be.equal(3);
       });
     });
-
   });
 
   describe('between & not between operators', () => {
@@ -1340,7 +1339,7 @@ describe('Feathers Objection Service', () => {
     });
 
     it('not Between using $not', () => {
-      return people.find({ query: { age: { $not : { $between: [0, 100] } } } }).then(data => {
+      return people.find({ query: { age: { $not: { $between: [0, 100] } } } }).then(data => {
         expect(data[0].name).to.be.equal('John');
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1132,7 +1132,6 @@ describe('Feathers Objection Service', () => {
 
       return companies
         .update(google.id, {
-          id: google.id,
           name: 'Alphabet',
           clients: newClients
         }).then(() => { // NOTE: Do not need $eager anymore
@@ -1151,6 +1150,24 @@ describe('Feathers Objection Service', () => {
 
       return companies
         .update(apple.id, {
+          id: google.id,
+          name: 'Alphabet',
+          clients: newClients
+        }).then(() => {
+          throw new Error('Should never get here');
+        }).catch(function (error) {
+          expect(error).to.be.ok;
+          expect(error instanceof errors.BadRequest).to.be.ok;
+        });
+    });
+
+    it('forbid upsertGraph if data do not match patch item', () => {
+      const newClients = (google.clients) ? google.clients.concat([{
+        name: 'Ken Patrick'
+      }]) : [];
+
+      return companies
+        .patch(apple.id, {
           id: google.id,
           name: 'Alphabet',
           clients: newClients

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1183,6 +1183,23 @@ describe('Feathers Objection Service', () => {
         });
     });
 
+    it('allows upsertGraph queries on patch with query param', () => {
+      const newClients = (google.clients) ? google.clients.concat([{
+        name: 'Ken Patrick'
+      }]) : [];
+
+      return companies
+        .patch(google.id, {
+          name: 'Google Alphabet',
+          clients: newClients
+        }, { query: { name: 'microsoft' } }).then(() => {
+          throw new Error('Should never get here');
+        }).catch(function (error) {
+          expect(error).to.be.ok;
+          expect(error instanceof errors.NotFound).to.be.ok;
+        });
+    });
+
     it('allows mergeAllowUpsert queries', () => {
       return companies.patch(google.id, { ceos: { id: ceo.id, name: 'Dog' } }, { mergeAllowUpsert: 'ceos' }).then(data => {
         expect(data.ceos.name).to.equal('Dog');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1363,7 +1363,7 @@ describe('Feathers Objection Service', () => {
             age: 1
           }
         );
-      return people.update(p.id, { age: 3, name: 'John' }, { query: { $select: ['name as n'] } }).then(data => {
+      return people.update(p.id, { age: 3, name: 'John' }, { query: { $select: ['people.name as n'] } }).then(data => {
         expect(data.n).to.be.equal('John');
         expect(data.age).to.be.equal(undefined);
       });
@@ -1377,11 +1377,13 @@ describe('Feathers Objection Service', () => {
             age: 1
           }
         );
-      return people.update(p.id, { id: p.id, age: 3, name: 'John' }, { query: { $select: ['name'] }, mergeAllowUpsert: 'company' }).then(data => {
+      return people.update(p.id, { id: p.id, age: 3, name: 'John' }, { query: { $select: ['people.age', 'people.name'] }, mergeAllowUpsert: 'company' }).then(data => {
         expect(data.name).to.be.equal('John');
-        expect(data.age).to.be.equal(undefined);
+        expect(data.age).to.be.equal(3);
       });
     });
+
+    // it.todo('$select and update upsert with relation fetching');
 
     it('$select and patch', async () => {
       const p = await people
@@ -1394,6 +1396,20 @@ describe('Feathers Objection Service', () => {
       return people.patch(p.id, { name: 'John' }, { query: { $select: ['name as n'] } }).then(data => {
         expect(data.n).to.be.equal('John');
         expect(data.age).to.be.equal(undefined);
+      });
+    });
+
+    it('$select all and patch upsert', async () => {
+      const p = await people
+        .create(
+          {
+            name: 'Dave',
+            age: 1
+          }
+        );
+      return people.patch(p.id, { name: 'John' }, { query: { $select: ['people.*'] }, mergeAllowUpsert: 'company' }).then(data => {
+        expect(data.name).to.be.equal('John');
+        expect(data.age).to.be.equal(1);
       });
     });
 


### PR DESCRIPTION
Hello,

Here are fixes for joinEager queries when using mergeEager and pagination.
And another commit include the $not operator.
**UPDATE** Plus I added fixes for $select, $noSelect and graph queries we discussed in #97 

Hope this helps.