### PR TITLE
Atomic graph mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Note that all this eager related options are optional.
   [`transaction`](https://vincit.github.io/objection.js/api/objection/#transaction)
   documentation.
 
+- **`$atomic`** - when `true` ensure that multi create or graph insert/upsert success or fail all at once. Under the hood, automaticaly create a transaction and commit on success or rollback on partial or total failure. __Ignored__ if you added your own `transaction` object in params.
+
 - **`mergeAllowEager`** - Will merge the given expression to the existing expression from the `allowEager` service option. 
   See [`allowGraph`](https://vincit.github.io/objection.js/api/query-builder/eager-methods.html#allowgraph)
   documentation.

--- a/src/index.js
+++ b/src/index.js
@@ -315,14 +315,13 @@ class Service extends AdapterService {
   }
 
   async _createTransaction (params) {
-    const autoStartTransaction = !params.transaction && params.$startTransaction;
-    if (autoStartTransaction) {
-      delete params.$startTransaction;
+    if (!params.transaction && params.$atomic) {
+      delete params.$atomic;
       params.transaction = params.transaction || {};
       params.transaction.trx = await this.Model.startTransaction();
       return params.transaction;
     }
-    return autoStartTransaction;
+    return null;
   }
 
   _commitTransaction (transaction) {

--- a/src/index.js
+++ b/src/index.js
@@ -318,8 +318,14 @@ class Service extends AdapterService {
     const trx = params.transaction ? params.transaction.trx : null;
     const schema = params.schema || this.schema;
     const query = this.Model.query(trx);
-
-    return schema ? query.withSchema(schema) : query;
+    if (schema) {
+      query.context({
+        onBuild (builder) {
+          builder.withSchema(schema);
+        }
+      });
+    }
+    return query;
   }
 
   _selectQuery (q, $select) {


### PR DESCRIPTION
Here is a small patch to fix schema with graph use (as seen in Objection [doc](https://vincit.github.io/objection.js/api/query-builder/other-methods.html#context))

Biggest patch is about atomic transaction with upsert/insert graph and with multi create.
I added a $startTransaction param. But Maybe we should name it $atomic ?
