### PR TITLE
Add optional parameter modifierFiltersResults for disabling count of $modify query results

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ Note that all this eager related options are optional.
   See [`withSchema`](https://vincit.github.io/objection.js/api/query-builder/find-methods.html#withschema)
   documentation.
 
+- **`modifierFiltersResults`** - when `false` the `total` count of a `find()` query is calculated from the original result set, ignoring the `count` of any `$modify` query.
+  The default behaviour is to apply the count of the modifier to the result total, assuming that the modifier may influence the result total by filtering the result set. This can be used to workaround issues with `groupBy` and the result count. See [this issue](https://github.com/feathersjs-ecosystem/feathers-objection/issues/102) for a detailed explanation.
+
 ### Composite primary keys
 
 Composite primary keys can be passed as the `id` argument using the following

--- a/src/index.js
+++ b/src/index.js
@@ -574,7 +574,7 @@ class Service extends AdapterService {
           countQuery.count({ total: countColumns });
         }
 
-        if (query && query.$modify) {
+        if (query && query.$modify && params.modifierFiltersResults !== false) {
           this.modifyQuery(countQuery, query.$modify);
         }
 

--- a/test/company.js
+++ b/test/company.js
@@ -57,6 +57,9 @@ export default class Company extends Model {
     },
     withRelation: builder => {
       builder.withGraphFetched('employees');
+    },
+    withRelationAndGroupBy: builder => {
+      builder.withGraphFetched('employees').groupBy('id');
     }
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2098,6 +2098,36 @@ describe('Feathers Objection Service', () => {
       });
     });
 
+    it('params.modifierFiltersResults=false does not apply count from modify query', () => {
+      companies.options.paginate = {
+        default: 2,
+        max: 2
+      };
+
+      return companies.find({
+        query: { $modify: ['google'] }, modifierFiltersResults: false
+      }).then(data => {
+        expect(data.total).to.be.equal(2);
+        expect(data.data.length).to.be.equal(1);
+        expect(data.data[0].name).to.be.equal('Google');
+      });
+    });
+
+    it('params.modifierFiltersResults=true does not apply count from modify query', () => {
+      companies.options.paginate = {
+        default: 2,
+        max: 2
+      };
+
+      return companies.find({
+        query: { $modify: ['google'] }, modifierFiltersResults: true
+      }).then(data => {
+        expect(data.total).to.be.equal(1);
+        expect(data.data.length).to.be.equal(1);
+        expect(data.data[0].name).to.be.equal('Google');
+      });
+    });
+
     it('allow $modify query with paginate, groupBy and joinRelation', () => {
       companies.options.paginate = {
         default: 1,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2105,25 +2105,38 @@ describe('Feathers Objection Service', () => {
       };
 
       return companies.find({
-        query: { $modify: ['google'] }, modifierFiltersResults: false
+        query: { $modify: ['withRelationAndGroupBy'] }, modifierFiltersResults: false
       }).then(data => {
         expect(data.total).to.be.equal(2);
-        expect(data.data.length).to.be.equal(1);
+        expect(data.data.length).to.be.equal(2);
         expect(data.data[0].name).to.be.equal('Google');
       });
     });
 
-    it('params.modifierFiltersResults=true does not apply count from modify query', () => {
+    it('params.modifierFiltersResults=true applies count from modify query', () => {
       companies.options.paginate = {
         default: 2,
         max: 2
       };
 
       return companies.find({
-        query: { $modify: ['google'] }, modifierFiltersResults: true
+        query: { $modify: ['withRelationAndGroupBy'] }, modifierFiltersResults: true
       }).then(data => {
-        expect(data.total).to.be.equal(1);
-        expect(data.data.length).to.be.equal(1);
+        expect(data.total).to.be.equal(1); // count result from GROUP BY
+        expect(data.data.length).to.be.equal(2);
+        expect(data.data[0].name).to.be.equal('Google');
+      });
+    });
+
+    it('params.modifierFiltersResults=undefined applies count from modify query', () => {
+      companies.options.paginate = {
+        default: 2,
+        max: 2
+      };
+
+      return companies.find({ query: { $modify: ['withRelationAndGroupBy'] } }).then(data => {
+        expect(data.total).to.be.equal(1); // count result from GROUP BY
+        expect(data.data.length).to.be.equal(2);
         expect(data.data[0].name).to.be.equal('Google');
       });
     });


### PR DESCRIPTION
Adds an optional parameter for allowing `find()` queries to opt-out of applying the result of  any modifiers to the returned `total`. 
Works around the issue with the total of `groupBy` described in https://github.com/feathersjs-ecosystem/feathers-objection/issues/102
The parameter can be safely set to `false` for any query with a modifier which does not filter the result set but only enhances it with additional data, e.h. `withGraphFetched`.