### PR TITLE
Fixed issue where using $select with a composite PK returns error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -358,7 +358,7 @@ class Service extends AdapterService {
 
   _selectQuery (q, $select) {
     if ($select && Array.isArray($select)) {
-      const items = $select.concat(`${this.Model.tableName}.${this.id}`);
+      const items = $select.concat(Array.isArray(this.id) ? this.id.map(el => { return `${this.Model.tableName}.${el}`; }) : `${this.Model.tableName}.${this.id}`);
 
       for (const [key, item] of Object.entries(items)) {
         const matches = item.match(/^ref\((.+)\)( as (.+))?$/);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -619,6 +619,20 @@ describe('Feathers Objection Service', () => {
         });
       });
     });
+
+    it('allows get queries with $select', () => {
+      return peopleRooms.get([2, 2], { query: { $select: ['admin'] } }).then(data => {
+        expect(data.admin).to.equal(1);
+      });
+    });
+
+    it('allows find queries with $select', () => {
+      return peopleRooms.find({ query: { roomId: 2, $select: ['admin'] } }).then(data => {
+        expect(data.length).to.equal(2);
+        expect(data[0].admin).to.equal(0);
+        expect(data[1].admin).to.equal(1);
+      });
+    });
   });
 
   describe('Eager queries', () => {


### PR DESCRIPTION
When using $select in both get or find methods on models with a composite primary key, a database error is returned. 