### PR TITLE
fixed UniqueViolationError bug for mysql clients

### DIFF
--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -40,9 +40,9 @@ export default function errorHandler (error) {
     feathersError = new errors.NotFound(message);
   } else if (error instanceof UniqueViolationError) {
     if (error.client === 'mysql') {
-      feathersError = new errors.default.Conflict(error.nativeError.sqlMessage);
+      feathersError = new errors.Conflict(error.nativeError.sqlMessage);
     } else {
-      feathersError = new errors.default.Conflict(`${error.columns.join(', ')} must be unique`, {
+      feathersError = new errors.Conflict(`${error.columns.join(', ')} must be unique`, {
         columns: error.columns,
         table: error.table,
         constraint: error.constraint

--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -40,7 +40,9 @@ export default function errorHandler (error) {
     feathersError = new errors.NotFound(message);
   } else if (error instanceof UniqueViolationError) {
     if (error.client === 'mysql') {
-      feathersError = new errors.Conflict(error.nativeError.sqlMessage);
+      feathersError = new errors.Conflict(error.nativeError.sqlMessage, {
+        constraint: error.constraint
+      });
     } else {
       feathersError = new errors.Conflict(`${error.columns.join(', ')} must be unique`, {
         columns: error.columns,

--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -39,11 +39,15 @@ export default function errorHandler (error) {
   } else if (error instanceof NotFoundError) {
     feathersError = new errors.NotFound(message);
   } else if (error instanceof UniqueViolationError) {
-    feathersError = new errors.Conflict(`${error.columns.join(', ')} must be unique`, {
-      columns: error.columns,
-      table: error.table,
-      constraint: error.constraint
-    });
+    if (error.client === 'mysql') {
+      feathersError = new errors.default.Conflict(error.nativeError.sqlMessage);
+    } else {
+      feathersError = new errors.default.Conflict(`${error.columns.join(', ')} must be unique`, {
+        columns: error.columns,
+        table: error.table,
+        constraint: error.constraint
+      });
+    }
   } else if (error instanceof NotNullViolationError) {
     feathersError = new errors.BadRequest(`${error.column} must not be null`, {
       column: error.column,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -378,7 +378,8 @@ describe('Feathers Objection Service', () => {
           nativeError: { sqlMessage: 'test' },
           client: 'mysql',
           table: undefined,
-          columns: undefined
+          columns: undefined,
+          constraint: 'test_constraint'
         });
 
         expect(errorHandler.bind(null, error)).to.throw(error.Conflict, 'test');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -373,6 +373,17 @@ describe('Feathers Objection Service', () => {
         expect(errorHandler.bind(null, error)).to.throw(errors.Conflict);
       });
 
+      it('UniqueViolation error mysql', () => {
+        const error = new UniqueViolationError({
+          nativeError: { sqlMessage: 'test' },
+          client: 'mysql',
+          table: undefined,
+          columns: undefined
+        });
+
+        expect(errorHandler.bind(null, error)).to.throw(error.Conflict, 'test');
+      });
+
       it('ConstraintViolation error', () => {
         const error = new ConstraintViolationError({
           nativeError: new Error(),


### PR DESCRIPTION
Hi,

currently, I develop an app where users have an email which should be unique in the users table. So I added a unique index for the email column. 

But when tried to save a user with an email which is already used, feathers-objection throws the following error: `Cannot read property 'join' of undefined`

After some research I found out that the feathers-objection error handler tries to generate an error message with the following code:

```jsx
feathersError = new errors.Conflict(`${error.columns.join(', ')} must be unique`, {
  columns: error.columns,
  table: error.table,
  constraint: error.constraint
});
```

After some more research I found out that objection uses the [db-error](https://github.com/Vincit/db-errors) package. And [as documented](https://github.com/Vincit/db-errors#uniqueviolationerror) the `UniqueViolationError` does not support the `columns` field for mysql. 

This probably causes `error.columns` to be `undefined` and `error.columns.join(', ')` will not work.

I fixed the bug by checking if the `error.client` is `mysql` and if so the native `sqlMessage` will be thrown. I also added a test for this.

I hope it helps.