### PR TITLE
Handle missing top-level jsonSchema.properties in objectify()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -221,7 +221,7 @@ class Service extends AdapterService {
         return query[method].call(query, column, value); // eslint-disable-line no-useless-call
       }
 
-      const property = this.jsonSchema && (this.jsonSchema.properties[column] || (methodKey && this.jsonSchema.properties[methodKey]));
+      const property = this.jsonSchema && this.jsonSchema.properties && (this.jsonSchema.properties[column] || (methodKey && this.jsonSchema.properties[methodKey]));
       let columnType = property && property.type;
       if (columnType) {
         if (Array.isArray(columnType)) { columnType = columnType[0]; }


### PR DESCRIPTION
If the `jsonSchema` of an Objection model does not contain a top-level `properties` field, `objectify()` will currently fail with errors like `Cannot read property 'MyModel.id' of undefined`. This happens for instance when the count query after a create operation is executed.

Example schema:
```javascript
{
      type: 'object',
      allOf: [
        { 
           properties: { id: {type: 'string' }
        },
        {...}
    ]
}
```

The proposed sanity check allows to gracefully support JSON schemas that have use schema combination via `anyOf`, `allOf` etc. at the top-level