### PR TITLE
Remove groupBy when counting rows for pagination

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -558,7 +558,7 @@ class Service extends AdapterService {
 
       if (count) {
         const countColumns = groupByColumns || (Array.isArray(this.id) ? this.id.map(idKey => `${this.Model.tableName}.${idKey}`) : [`${this.Model.tableName}.${this.id}`]);
-        const countQuery = this._createQuery(params);
+        const countQuery = this._createQuery(params).clear('groupBy');
 
         if (query.$joinRelation) {
           countQuery


### PR DESCRIPTION
When counting rows for the pagination, `groupBy` is not necessary as we only need 1 row and `groupBy` can return multi-row when using `join` relation and `$in` operator in the where clause.