### PR TITLE
Remove GroupBy for Find Count queries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -578,7 +578,10 @@ class Service extends AdapterService {
           this.modifyQuery(countQuery, query.$modify);
         }
 
-        countQuery.clear('groupBy');
+        if (params.modifierFiltersResults !== false) {
+          countQuery.clear('groupBy');
+        }
+
         this.objectify(countQuery, query, null, null, query.$allowRefs);
 
         return countQuery

--- a/src/index.js
+++ b/src/index.js
@@ -558,7 +558,7 @@ class Service extends AdapterService {
 
       if (count) {
         const countColumns = groupByColumns || (Array.isArray(this.id) ? this.id.map(idKey => `${this.Model.tableName}.${idKey}`) : [`${this.Model.tableName}.${this.id}`]);
-        const countQuery = this._createQuery(params);
+        const countQuery = this._createQuery(params).clear('groupBy');
 
         if (query.$joinRelation) {
           countQuery

--- a/src/index.js
+++ b/src/index.js
@@ -558,7 +558,7 @@ class Service extends AdapterService {
 
       if (count) {
         const countColumns = groupByColumns || (Array.isArray(this.id) ? this.id.map(idKey => `${this.Model.tableName}.${idKey}`) : [`${this.Model.tableName}.${this.id}`]);
-        const countQuery = this._createQuery(params).clear('groupBy');
+        const countQuery = this._createQuery(params);
 
         if (query.$joinRelation) {
           countQuery
@@ -578,6 +578,7 @@ class Service extends AdapterService {
           this.modifyQuery(countQuery, query.$modify);
         }
 
+        countQuery.clear('groupBy');
         this.objectify(countQuery, query, null, null, query.$allowRefs);
 
         return countQuery

--- a/src/index.js
+++ b/src/index.js
@@ -558,7 +558,7 @@ class Service extends AdapterService {
 
       if (count) {
         const countColumns = groupByColumns || (Array.isArray(this.id) ? this.id.map(idKey => `${this.Model.tableName}.${idKey}`) : [`${this.Model.tableName}.${this.id}`]);
-        const countQuery = this._createQuery(params).clear('groupBy');
+        const countQuery = this._createQuery(params);
 
         if (query.$joinRelation) {
           countQuery

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2162,7 +2162,7 @@ describe('Feathers Objection Service', () => {
       return companies.find({
         query: { $modify: ['withRelationAndGroupBy'] }, modifierFiltersResults: true
       }).then(data => {
-        expect(data.total).to.be.equal(1); // count result from GROUP BY
+        expect(data.total).to.be.equal(2); // count result from GROUP BY
         expect(data.data.length).to.be.equal(2);
         expect(data.data[0].name).to.be.equal('Google');
       });
@@ -2175,7 +2175,7 @@ describe('Feathers Objection Service', () => {
       };
 
       return companies.find({ query: { $modify: ['withRelationAndGroupBy'] } }).then(data => {
-        expect(data.total).to.be.equal(1); // count result from GROUP BY
+        expect(data.total).to.be.equal(2); // count result from GROUP BY
         expect(data.data.length).to.be.equal(2);
         expect(data.data[0].name).to.be.equal('Google');
       });


### PR DESCRIPTION
An update for PR #150 as it wasn't clearing `groupBy` introduced by `$modify` queries